### PR TITLE
提案 1.18.1サポートの追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
     <groupId>net.teamfruit</groupId>
     <artifactId>sushida</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2-mc1.18.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Sushida</name>
 
     <description>寿司打</description>
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -79,7 +79,7 @@
 
     <repositories>
         <repository>
-            <id>papermc-repo</id>
+            <id>papermc</id>
             <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
         <repository>
@@ -90,9 +90,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
+            <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.15.2-R0.1-SNAPSHOT</version>
+            <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
1.15.2の依存関係のままだと最新バージョンのPaper(1.18.1)では正しい文字を入力したのにも関わらずミス判定になります
Paper-APIを最新版に更新してあげれば正しく判定されるようになりました
masterとは別ブランチで1.18.1サポートを追加するのはどうでしょうか